### PR TITLE
Fix mount dependency issue

### DIFF
--- a/src/useSimpleReveal.ts
+++ b/src/useSimpleReveal.ts
@@ -75,7 +75,7 @@ export function useSimpleReveal(param?: {
         obs.unobserve(current);
       };
     },
-    []
+    [mounted]
   );
 
   const cn = useCallback(


### PR DESCRIPTION
## Problem

- mount is used as a dependency of useEffectWithRefCurrent, but ignoreDelay is executed every time because it is not declared.

## Solve
- Fixed the issue mentioned above.